### PR TITLE
Fix solution relative path

### DIFF
--- a/SolutionFilterGenerator/FilterGenerator.cs
+++ b/SolutionFilterGenerator/FilterGenerator.cs
@@ -20,7 +20,10 @@ public static class FilterGenerator
             .Select(p => p.Path)
             .ToArray();
 
-        var relativeSlnPath = Path.GetRelativePath(outputPath ?? solutionFile.DirectoryName!, solutionFile.FullName);
+        var relativeTo = outputPath is null or ""
+            ? solutionFile.DirectoryName!
+            : new FileInfo(outputPath).DirectoryName ?? solutionFile.DirectoryName!; 
+        var relativeSlnPath = Path.GetRelativePath(relativeTo, solutionFile.FullName);
         return new SolutionFilter(new Solution(relativeSlnPath, filteredProjects));
     }
 }


### PR DESCRIPTION
`Path.GetRelativePath` should receive a directory as first parameter.
I was getting wrong relative path in output file because the solution name sent to `Path.GetRelativePath` was considered as another directory level.